### PR TITLE
Allow to filter the selected value on the onSelect callback

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -1,6 +1,7 @@
 /**
-*  Ajax Autocomplete for jQuery, version 1.1.5
+*  Ajax Autocomplete for jQuery, version 1.1.6
 *  (c) 2010 Tomas Kirda, Vytautas Pranskunas
+*  Some small addition by Luciano Mammino
 *
 *  Ajax Autocomplete for jQuery is freely distributable under the terms of an MIT-style license.
 *  For details, see the web site: http://www.devbridge.com/projects/autocomplete/jquery/


### PR DESCRIPTION
Allows to return a string on the onSelect method that filters out the value that will be set on the input field.

E.g.

```
$('._autocomplete').autocomplete({
    onSelect : function(value, data, input)
    {
        return 'Filtered value: ' + data.value;
    }
});
```

If selecting _New York_ will set the input text value as _Filtered value: New York_
