### PR TITLE
Allows to configure requestMethod. 

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -36,7 +36,7 @@
 		this.serviceUrl = options.serviceUrl;
 		this.isLocal = false;
 		this.options = {
-            requestMethod = 'get',
+            		requestMethod: 'get',
 			autoSubmit: false,
 			minChars: 1,
 			maxHeight: 300,


### PR DESCRIPTION
You can choose between Post and Get methods.

New option added: `requestMethod`, default value: `get`
