### PR TITLE
Update src/jquery.autocomplete.js

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -361,7 +361,10 @@
             var response;
 
             try {
-                response = eval('(' + text + ')');
+                if (typeof(JSON) != "undefined" && typeof(JSON.parse) != "undefined")
+                    response = JSON.parse(text);
+                else
+                    response = eval('(' + text + ')');
             } catch (err) {
                 return;
             }


### PR DESCRIPTION
Using the native JSON.parse built-in function in the browsers if it's available.
Adds more security to it, so the autocomplete is less prone to XSS attacks.
