### PR TITLE
add an option to disable going to the next field when tabbing to select ...

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ The standard jquery.autocomplete.js file is around 2.7KB when minified via Closu
         * `noCache`: Boolean value indicating whether to cache suggestion results. Default `true`.
         * `onSearchStart`: `function (query) {}` called before ajax request. `this` is bound to input element.
         * `onSearchComplete`: `function (query) {}` called after ajax response is processed. `this` is bound to input element.
+        * `tabDisabled`: Default `false`. Set to true to leave the cursor in the input field after the user tabs to select a suggestion.
 
 ##Usage
 

--- a/spec/autocompleteBehavior.js
+++ b/spec/autocompleteBehavior.js
@@ -137,4 +137,54 @@ describe('Autocomplete', function () {
             expect(completeQuery).toBe('A');
         });
     });
+
+    it('Should should not preventDefault when tabDisabled is set to false', function () {
+        var input = document.createElement('input'),
+            autocomplete = new $.Autocomplete(input, {
+                lookup: [{ value: 'Jamaica', data: 'B' }],
+                tabDisabled: false});
+        input.value = 'Jam';
+        autocomplete.onValueChange();
+
+        var event = $.Event('keydown');
+        event.keyCode = 9; // the tab keycode
+        spyOn(event, 'stopImmediatePropagation');
+        spyOn(event, 'preventDefault');
+        spyOn(autocomplete, 'suggest');
+
+        expect(autocomplete.visible).toBe(true);
+        expect(autocomplete.disabled).toBe(undefined);
+        expect(autocomplete.selectedIndex).not.toBe(-1);
+
+        $(input).trigger(event);
+
+        expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(autocomplete.suggest).not.toHaveBeenCalled();
+    });
+
+    it('Should should preventDefault when tabDisabled is set to true', function () {
+        var input = document.createElement('input'),
+            autocomplete = new $.Autocomplete(input, {
+                lookup: [{ value: 'Jamaica', data: 'B' }],
+                tabDisabled: true});
+        input.value = 'Jam';
+        autocomplete.onValueChange();
+
+        var event = $.Event('keydown');
+        event.keyCode = 9; // the tab keycode
+        spyOn(event, 'stopImmediatePropagation');
+        spyOn(event, 'preventDefault');
+        spyOn(autocomplete, 'suggest');
+
+        expect(autocomplete.visible).toBe(true);
+        expect(autocomplete.disabled).toBe(undefined);
+        expect(autocomplete.selectedIndex).not.toBe(-1);
+
+        $(input).trigger(event);
+
+        expect(event.stopImmediatePropagation).toHaveBeenCalled();
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(autocomplete.suggest).not.toHaveBeenCalled();
+    });
 });

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -75,7 +75,8 @@
                 noCache: false,
                 onSearchStart: noop,
                 onSearchComplete: noop,
-                containerClass: 'autocomplete-suggestions'
+                containerClass: 'autocomplete-suggestions',
+                tabDisabled: false
             };
 
         // Shared variables:
@@ -257,7 +258,7 @@
                         return;
                     }
                     this.select(this.selectedIndex);
-                    if (e.keyCode === keys.TAB) {
+                    if (e.keyCode === keys.TAB && this.options.tabDisabled === false) {
                         return;
                     }
                     break;


### PR DESCRIPTION
Without this change, hitting tab when the suggestion list is down will go to the next field, but I want the cursor to stay in the same field. Hopefully you'll merge this in so I don't have to monkey patch - this is behavior that existed in the Prototype autocomplete that I'm replacing in my app.
