### PR TITLE
Removing empty query validation on value change

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -359,7 +359,7 @@
                 return;
             }
 
-            if (q === '' || q.length < that.options.minChars) {
+            if (q.length < that.options.minChars) {
                 that.hide();
             } else {
                 that.getSuggestions(q);


### PR DESCRIPTION
Removing empty query validation on value change, so I can set 'minChars' to 0 and show suggestions when the user click on input.

Exemple:

var $autocomplete = new $.Autocomplete($('#wishlist_name')[0], {
    lookup: wishlist_types,
    minChars: 0,
});

$('#wishlist_name').focus(function(){
    $autocomplete.onValueChange();
});
