### PR TITLE
Numerical HTML Entity Encoding

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -580,7 +580,15 @@
                 $(that.suggestionsContainer).scrollTop(offsetTop - that.options.maxHeight + heightDelta);
             }
 
-            that.el.val(that.getValue(that.suggestions[index].value));
+            // FIX: Special characters appears with numerical html entity encoding like "c&#39;est la vie" instead of "c'est la vie"
+            // ------------------------------------------------------------------------------------------------------------------
+            var value = that.getValue(that.suggestions[index].value);
+            // Apply regex to decode special characters
+            value = value.replace(/&#([^\s]*);/g, function (match, match2) { return String.fromCharCode(Number(match2)); });
+            that.el.val(value);
+
+            // Original Code:
+            //that.el.val(that.getValue(that.suggestions[index].value));
         },
 
         onSelect: function (index) {


### PR DESCRIPTION
When using the component with languages containing special chars in data source, the component, at selecting an item, doesn't scape numerical HTML entities, ie. "c'est la vie" results in "c&# 39;est la vie" (without whitespace after '#').

![cestlavi](https://f.cloud.github.com/assets/2868031/288417/75f1dfbe-9274-11e2-8572-24cd40153157.png)

To fix the problem, I inserted a regex expression that decodes the value of selected suggestion before put it into the inputbox.
