### PR TITLE
Allowing not 'GET' searchs

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -404,8 +404,8 @@
                 options.params[options.paramName] = q;
                 options.onSearchStart.call(that.element, options.params);
                 $.ajax({
-                    url: options.serviceUrl,
-                    data: options.params,
+                    url: options.paramName ? options.serviceUrl : options.serviceUrl+q,
+                    data: options.paramName ? options.params : null,
                     type: options.type,
                     dataType: options.dataType
                 }).done(function (data) {


### PR DESCRIPTION
With this little mod we can allow the user to choose to make a "REST-like" search (that's without a query parameter name... the url is the actual resource)

(for example: resource/search/<name>)
