### PR TITLE
Add onSearchError callback for handling AJAX failures

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ The standard jquery.autocomplete.js file is around 2.7KB when minified via Closu
         * `noCache`: Boolean value indicating whether to cache suggestion results. Default `false`.
         * `onSearchStart`: `function (query) {}` called before ajax request. `this` is bound to input element.
         * `onSearchComplete`: `function (query) {}` called after ajax response is processed. `this` is bound to input element.
+        * `onSearchError`: `function (query, jqXHR, textStatus, errorThrown) {}` called if ajax request fails. `this` is bound to input element.
         * `tabDisabled`: Default `false`. Set to true to leave the cursor in the input field after the user tabs to select a suggestion.
         * `paramName`: Default `query`. The name of the request parameter that contains the query.
         * `transformResult`: `function(response, originalQuery) {}` called after the result of the query is ready. Converts the result into response.suggestions format.

--- a/spec/autocompleteBehavior.js
+++ b/spec/autocompleteBehavior.js
@@ -171,6 +171,41 @@ describe('Autocomplete', function () {
         });
     });
 
+    it('Should execute onSearchError', function () {
+        var input = document.createElement('input'),
+            ajaxExecuted = false,
+            errorMessage = false,
+            url = '/test-error',
+            autocomplete = new $.Autocomplete(input, {
+                serviceUrl: url,
+                onSearchError: function (q, jqXHR, textStatus, errorThrown) {
+                    errorMessage = jqXHR.responseText;
+                }
+            });
+
+        $.mockjax({
+            url: url,
+            responseTime: 50,
+            status: 500,
+            response: function (settings) {
+                ajaxExecuted = true;
+                this.responseText = "An error occurred";
+            }
+        });
+
+        input.value = 'A';
+        autocomplete.onValueChange();
+
+        waitsFor(function () {
+            return ajaxExecuted;
+        }, 'Ajax call never completed.', 100);
+
+        runs(function () {
+            expect(ajaxExecuted).toBe(true);
+            expect(errorMessage).toBe("An error occurred");
+        });
+    });
+
     it('Should transform results', function () {
         var input = document.createElement('input'),
             ajaxExecuted = false,

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -68,6 +68,7 @@
                 noCache: false,
                 onSearchStart: noop,
                 onSearchComplete: noop,
+                onSearchError: noop,
                 containerClass: 'autocomplete-suggestions',
                 tabDisabled: false,
                 dataType: 'text',
@@ -441,6 +442,8 @@
                 }).done(function (data) {
                     that.processResponse(data, q);
                     options.onSearchComplete.call(that.element, q);
+                }).fail(function (jqXHR, textStatus, errorThrown) {
+                    options.onSearchError.call(that.element, q, jqXHR, textStatus, errorThrown);
                 });
             }
         },


### PR DESCRIPTION
This PR allows handling AJAX failures through a new `onSearchError` callback. I tried to adhere to both the libraries as well as jQueries standard method signatures.
