### PR TITLE
Autocomplete dynamic lookup feature 

### DIFF
--- a/spec/autocompleteBehavior.js
+++ b/spec/autocompleteBehavior.js
@@ -51,7 +51,7 @@ describe('Autocomplete', function () {
                     counter += 1;
                 }
             });
-
+        
         input.value = 'Jam';
         autocomplete.onValueChange();
 
@@ -456,6 +456,8 @@ describe('Autocomplete', function () {
             expect(data).toBeFalsy();
         });
     });
+    
+ 
 
     it('Should set width to be greater than zero', function () {
         var input = $(document.createElement('input')),
@@ -472,5 +474,28 @@ describe('Autocomplete', function () {
         width = $(instance.suggestionsContainer).width();
 
         expect(width).toBeGreaterThan(0);
+    });
+    
+    it("Should accept lookup param as a callback function", function () {
+        var input = document.createElement('input'),
+            data = ['Jamaica', 'Jamaica', 'Jamaica', 'Jammy', 'Jammin'],
+            
+           autocomplete = new $.Autocomplete(input, {
+                lookup: function (request, response) {
+                    console.log(data);
+                    response(data);
+                }
+            });
+            console.log(autocomplete.options.lookup, autocomplete.suggestions);
+            expect(autocomplete.isLocal).toBe(true);
+            expect(autocomplete.options.lookup).toEqual($.map(data, function (value) {
+                return { value: value, data: null };
+            }));
+            input.value = 'Jam';
+            autocomplete.onValueChange();
+    
+            expect(autocomplete.visible).toBe(true);
+            expect(autocomplete.currentValue).toEqual('Jam');
+            //console.log(autocomplete);
     });
 });

--- a/spec/autocompleteBehavior.js
+++ b/spec/autocompleteBehavior.js
@@ -497,7 +497,7 @@ describe('Autocomplete', function () {
     
             expect(autocomplete.visible).toBe(true);
             expect(autocomplete.currentValue).toEqual('Jam');
-            
+           
             input.value = 'Match';
             autocomplete.onValueChange();
             expect(autocomplete.suggestions).toEqual([]);

--- a/spec/autocompleteBehavior.js
+++ b/spec/autocompleteBehavior.js
@@ -482,17 +482,18 @@ describe('Autocomplete', function () {
             
            autocomplete = new $.Autocomplete(input, {
                 lookup: function (request, response) {
-                    console.log(data);
                     response(data);
                 }
             });
-            console.log(autocomplete.options.lookup, autocomplete.suggestions);
+            
             expect(autocomplete.isLocal).toBe(true);
+            
+            input.value = 'Jam';
+            autocomplete.onValueChange();
+            
             expect(autocomplete.options.lookup).toEqual($.map(data, function (value) {
                 return { value: value, data: null };
             }));
-            input.value = 'Jam';
-            autocomplete.onValueChange();
     
             expect(autocomplete.visible).toBe(true);
             expect(autocomplete.currentValue).toEqual('Jam');

--- a/spec/autocompleteBehavior.js
+++ b/spec/autocompleteBehavior.js
@@ -497,6 +497,9 @@ describe('Autocomplete', function () {
     
             expect(autocomplete.visible).toBe(true);
             expect(autocomplete.currentValue).toEqual('Jam');
-            //console.log(autocomplete);
+            
+            input.value = 'Match';
+            autocomplete.onValueChange();
+            expect(autocomplete.suggestions).toEqual([]);
     });
 });

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -194,7 +194,12 @@
 
             $.extend(options, suppliedOptions);
 
-            that.isLocal = $.isArray(options.lookup) || $.isFunction(options.lookup);
+             if($.isFunction(options.lookup)){
+                that.shouldResolve = true;
+                that.originalLookup = options.lookup;
+            }
+            
+            that.isLocal = $.isArray(options.lookup) || that.shouldResolve;
 
             if (that.isLocal) {
                 options.lookup = that.verifySuggestionsFormat(options.lookup);
@@ -386,10 +391,10 @@
                 that.hide();
             } else {
                 
-                if(!$.isFunction(that.options.lookup)){
+                if (!that.shouldResolve) {
                     that.getSuggestions(q);
-                }else {
-                    that.options.lookup(this.currentValue, that.resolveLookup(q));
+                } else {
+                    that.originalLookup(this.currentValue, that.resolveLookup(q));
                 }    
                 
             }

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -194,7 +194,7 @@
 
             $.extend(options, suppliedOptions);
 
-            that.isLocal = $.isArray(options.lookup);
+            that.isLocal = $.isArray(options.lookup) || $.isFunction(options.lookup);
 
             if (that.isLocal) {
                 options.lookup = that.verifySuggestionsFormat(options.lookup);
@@ -385,7 +385,13 @@
             if (q.length < that.options.minChars) {
                 that.hide();
             } else {
-                that.getSuggestions(q);
+                
+                if(!$.isFunction(that.options.lookup)){
+                    that.getSuggestions(q);
+                }else {
+                    that.options.lookup(this.currentValue, that.resolveLookup(q));
+                }    
+                
             }
         },
 
@@ -411,15 +417,23 @@
                 })
             };
         },
-
+        
+        resolveLookup: function(query){
+            var that = this;
+            return $.proxy(function( content ) {
+                that.options.lookup = that.verifySuggestionsFormat(content);
+                that.getSuggestions(query);
+            }, this );
+        },
+        
         getSuggestions: function (q) {
             var response,
                 that = this,
                 options = that.options,
                 serviceUrl = options.serviceUrl;
-
+                
             response = that.isLocal ? that.getSuggestionsLocal(q) : that.cachedResponse[q];
-
+           
             if (response && $.isArray(response.suggestions)) {
                 that.suggestions = response.suggestions;
                 that.suggest();
@@ -550,7 +564,6 @@
                     return { value: value, data: null };
                 });
             }
-
             return suggestions;
         },
 


### PR DESCRIPTION
I have added a  very valuable feature that I borrowed idea from jQueryUI autocomplete widget.
Now, "lookup" option is able to take a function as a value for example: 

function( value, response ) {
// here goes some code and calculations

// update lookup data 
response(myAutoCompleteData);
}
as lookup function gets fired on every value change. 

This is very useful when you need to work with dynamic,live binded local autocomplete data / collections and other APIs such as Google Maps etc.. 

If you need anything else for this feature to get merged other than unit test I had added, just tell me and I'll be happy to add.
If this doesn't get merged, anyone else needing this can clone my forked repo. 
