### PR TITLE
Call a method for mouse or keyboard 'pre-selection'

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -64,7 +64,7 @@
                 deferRequestBy: 0,
                 params: {},
                 formatResult: Autocomplete.formatResult,
-                onMouseEnter: function(suggestion, divEl) {},
+                onPreSelect: function(suggestion, divEl) {},
                 delimiter: null,
                 zIndex: 9999,
                 type: 'GET',
@@ -159,13 +159,13 @@
             // http://api.jquery.com/on/#on-events-selector-data
             // Listen for mouse over event on suggestions list:
             container.on('mouseenter.autocomplete', suggestionSelector, function () {
-                console.log("enter");
+                // console.log("enter");
                 that.activate($(this).data('index'));
             });
 
             // Deselect active element when mouse leaves suggestions container:
             container.on('mouseleave.autocomplete', suggestionSelector, function () {                
-                console.log("leave");
+                // console.log("leave");
                 that.selectedIndex = -1;
                 container.children('.' + selected).removeClass(selected);
             });
@@ -683,7 +683,7 @@
             if (that.selectedIndex !== -1 && children.length > that.selectedIndex) {
                 activeItem = children.get(that.selectedIndex);
                 $(activeItem).addClass(selected);
-                that.options.onMouseEnter(that.suggestions[index], activeItem);
+                that.options.onPreSelect(that.suggestions[index], activeItem);
                 return activeItem;
             }
 

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -64,6 +64,7 @@
                 deferRequestBy: 0,
                 params: {},
                 formatResult: Autocomplete.formatResult,
+                onMouseEnter: function(suggestion, divEl) {},
                 delimiter: null,
                 zIndex: 9999,
                 type: 'GET',
@@ -153,14 +154,18 @@
             if (options.width !== 'auto') {
                 container.width(options.width);
             }
-
+            
+            // special on() plugin code for 'autocomplete'
+            // http://api.jquery.com/on/#on-events-selector-data
             // Listen for mouse over event on suggestions list:
-            container.on('mouseover.autocomplete', suggestionSelector, function () {
+            container.on('mouseenter.autocomplete', suggestionSelector, function () {
+                console.log("enter");
                 that.activate($(this).data('index'));
             });
 
             // Deselect active element when mouse leaves suggestions container:
-            container.on('mouseout.autocomplete', function () {
+            container.on('mouseleave.autocomplete', suggestionSelector, function () {                
+                console.log("leave");
                 that.selectedIndex = -1;
                 container.children('.' + selected).removeClass(selected);
             });
@@ -247,7 +252,7 @@
                 offset,
                 styles;
 
-            // Don't adjsut position if custom container has been specified:
+            // Don't adjust position if custom container has been specified:
             if (that.options.appendTo !== 'body') {
                 return;
             }
@@ -668,13 +673,17 @@
                 container = $(that.suggestionsContainer),
                 children = container.children();
 
-            container.children('.' + selected).removeClass(selected);
-
+            if(that.selectedIndex === index)
+                return null;
+            
+            container.children('.' + selected).removeClass(selected);            
+            
             that.selectedIndex = index;
-
+            
             if (that.selectedIndex !== -1 && children.length > that.selectedIndex) {
                 activeItem = children.get(that.selectedIndex);
                 $(activeItem).addClass(selected);
+                that.options.onMouseEnter(that.suggestions[index], activeItem);
                 return activeItem;
             }
 


### PR DESCRIPTION
When doing mouse over or doing up+down with the keyboard I wanted to call a kind of preview on my site. So I needed a hook for that. Which requires some changes. E.g. the event name mouseover.autocomplete->mouseenter.autocomplete and mouseleave as otherwise the events were called too often: one time for the highlighted part and one for the normal text. 

Please have a look as this plugin jquery magic is very new to me.
