### PR TITLE
Add onMove callback

### DIFF
--- a/spec/autocompleteBehavior.js
+++ b/spec/autocompleteBehavior.js
@@ -597,4 +597,90 @@ describe('Autocomplete', function () {
 
         expect(instance.suggestions.length).toBe(limit);
     });
+
+    it('Verify moveOn with moveDown', function () {
+        var input = document.createElement('input'),
+            context,
+            value,
+            data,
+            autocomplete = $(input).autocomplete({
+                lookup: [
+                    { value: 'AB', data: 'A1' } ,
+                    { value: 'AC', data: 'A2' }
+                ],
+                triggerSelectOnValidInput: false,
+                onMove: function (suggestion) {
+                    context = this;
+                    value = suggestion.value;
+                    data = suggestion.data;
+                }
+            }).autocomplete();
+
+        input.value = 'A';
+        autocomplete.onValueChange();
+
+        autocomplete.moveDown();//onMove in moveDown() is called
+        expect(context).toEqual(input);
+        expect(value).toEqual('AB');
+        expect(data).toEqual('A1');
+
+        value = undefined;
+        data = undefined;
+        autocomplete.moveDown();//onMove in moveDown() is called
+        expect(value).toEqual('AC');
+        expect(data).toEqual('A2');
+
+        value = undefined;
+        data = undefined;
+        autocomplete.moveDown();//onMove in moveDown() is not called when the selectedIndex points last item
+        expect(value).toEqual(undefined);
+        expect(data).toEqual(undefined);
+
+
+    });
+
+    it('Verify moveOn with moveUp', function () {
+        var input = document.createElement('input'),
+            context,
+            value,
+            data,
+            autocomplete = $(input).autocomplete({
+                lookup: [
+                    { value: 'AB', data: 'A1' } ,
+                    { value: 'AC', data: 'A2' }
+                ],
+                triggerSelectOnValidInput: false,
+                onMove: function (suggestion) {
+                    context = this;
+                    value = suggestion.value;
+                    data = suggestion.data;
+                }
+            }).autocomplete();
+
+        input.value = 'A';
+        autocomplete.onValueChange();
+        autocomplete.selectedIndex = -1;
+        autocomplete.moveUp();//onMove in moveUp() callback is not called when selectedIndex = -1
+        expect(context).toEqual(undefined);
+        expect(value).toEqual(undefined);
+        expect(data).toEqual(undefined);
+
+        autocomplete.selectedIndex = 0;
+        value = undefined;
+        data = undefined;
+        autocomplete.moveUp();//onMove in moveUp() callback is not called when selectedIndex = 0
+        expect(value).toEqual(undefined);
+        expect(data).toEqual(undefined);
+
+        autocomplete.onValueChange();
+        autocomplete.moveDown();
+        expect(value).toEqual('AB');
+        expect(data).toEqual('A1');
+        autocomplete.moveDown();
+        expect(value).toEqual('AC');
+        expect(data).toEqual('A2');
+        autocomplete.moveUp();//onMove in moveUp() is called
+        expect(value).toEqual('AB');
+        expect(data).toEqual('A1');
+    });
 });

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -58,6 +58,7 @@
                 serviceUrl: null,
                 lookup: null,
                 onSelect: null,
+                onMove: null,
                 width: 'auto',
                 minChars: 1,
                 maxHeight: 300,
@@ -695,7 +696,9 @@
         },
 
         moveUp: function () {
-            var that = this;
+            var that = this,
+                onMoveCallback = that.options.onMove,
+                nextIndex = that.selectedIndex - 1;
 
             if (that.selectedIndex === -1) {
                 return;
@@ -709,17 +712,27 @@
                 return;
             }
 
-            that.adjustScroll(that.selectedIndex - 1);
+            that.adjustScroll(nextIndex);
+
+            if($.isFunction(onMoveCallback)){
+                onMoveCallback.call(that.element,that.suggestions[nextIndex]);
+            }
         },
 
         moveDown: function () {
-            var that = this;
+            var that = this,
+                onMoveCallback = that.options.onMove,
+                nextIndex = that.selectedIndex + 1;
 
             if (that.selectedIndex === (that.suggestions.length - 1)) {
                 return;
             }
 
-            that.adjustScroll(that.selectedIndex + 1);
+            that.adjustScroll(nextIndex);
+
+            if($.isFunction(onMoveCallback)){
+                onMoveCallback.call(that.element,that.suggestions[nextIndex]);
+            }
         },
 
         adjustScroll: function (index) {


### PR DESCRIPTION
I added "onMove" callback option.

User can set onMove callback function. 
onMove callback runs  when suggested item changed with moveDown() and moveUp().

sample:

```
var autocomplete = $(input).autocomplete({
    lookup: [
                  { value: 'AB', data: 'A1' } ,
                  { value: 'AC', data: 'A2' }
            ],
    triggerSelectOnValidInput: false,
    onMove: function (suggestion) {
                  context = this;
                  value = suggestion.value;
                  data = suggestion.data;
             }
}).autocomplete();
```

I use this feature in addition to "onSelect" in order to measure the usage of function suggest.
