### PR TITLE
`onSearchComplete` receives `suggestions` as parameter and `options` now includes `keyPath`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ The standard jquery.autocomplete.js file is around 2.7KB when minified via Closu
     * Sets up autocomplete for input field(s).
     * `options`: An object literal which defines the settings to use for the autocomplete plugin.
         * `serviceUrl`: Server side URL or callback function that returns serviceUrl string. Optional if local lookup data is provided.
+        * `keyPath`: (by default `suggestions`). The key of the response where the array of results is.
         * `lookup`: Lookup array for the suggestions. It may be array of strings or `suggestion` object literals.
             * `suggestion`: An object literal with the following format: `{ value: 'string', data: any }`.
         * `lookupFilter`: `function (suggestion, query, queryLowerCase) {}` filter function for local lookups. By default it does partial string match (case insensitive).
@@ -150,6 +151,14 @@ you can supply the "paramName" and "transformResult" options:
                 })
             };
         }
+    })
+
+If your ajax service responds with a key different than `suggestions`, you can use `keyPath`:
+
+For example, if your server responds with: `{items: [{value: 'Item 1'}, {value: 'Item 2'}]}`:
+    
+    $('#autocomplete').autocomplete({
+        keyPath: "items"
     })
 
 

--- a/spec/autocompleteBehavior.js
+++ b/spec/autocompleteBehavior.js
@@ -654,4 +654,40 @@ describe('Autocomplete', function () {
             expect(ajaxCount).toBe(2);
         });
     });
+
+    it('Should accept the key as an option', function () {
+        var input = $('<input />'),
+            instance,
+            ajaxExecuted,
+            serviceUrl = "/items.json";
+
+
+        input.autocomplete({
+            serviceUrl: serviceUrl,
+            keyPath: "items"
+        });
+
+        $.mockjax({
+            url: serviceUrl,
+            responseTime: 5,
+            response: function (settings) {
+                ajaxExecuted = true;
+                var response = {
+                    items: [{value: "Item 1", id: 1}, {value: "Item 2", id: 2}, {value: "Item 3", id: 3}, {value: "Item 4", id: 4}]
+                };
+                this.responseText = JSON.stringify(response);
+            }
+        });
+
+        input.val("item");
+        instance = input.autocomplete();
+        instance.onValueChange();
+
+        waits(10);
+
+        runs(function() {
+            expect(ajaxExecuted).toBeTruthy();
+            expect(instance.suggestions.length).toBe(4);
+        });
+    });
 });

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -57,6 +57,7 @@
                 appendTo: 'body',
                 serviceUrl: null,
                 lookup: null,
+                keyPath: "suggestions",
                 onSelect: null,
                 width: 'auto',
                 minChars: 1,
@@ -648,7 +649,7 @@
             var that = this,
                 options = that.options;
 
-            result.suggestions = that.verifySuggestionsFormat(result.suggestions);
+            result.suggestions = that.verifySuggestionsFormat(result[options.keyPath]);
 
             // Cache results if cache is not disabled:
             if (!options.noCache) {


### PR DESCRIPTION
The thing is I have an Ember.js app. And when I fetch these suggestions, I'd like to push them to the store so that I can work with them later. Something like this:

```
$(input).autocomplete({
  onSearchComplete: function (query, items) {
    for (i=0; i<items.length; i++) {
      store.push("item", items[i]);
    }
  }
});
```

Also, my server returns a response like this: `{items: [{value: 'Item 1'},{value: 'Item 2'}]`. I want to be able to specify the key in the response. (Implemented as an option named `keyPath`)
