### PR TITLE
Option to auto-position the suggestions even when not appended to the body

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -100,6 +100,9 @@
         that.isLocal = false;
         that.suggestionsContainer = null;
         that.options = $.extend({}, defaults, options);
+        if (!("autoPosition" in that.options)) {
+            that.options.autoPosition = (that.options.appendTo === 'body');
+        }
         that.classes = {
             selected: 'autocomplete-selected',
             suggestion: 'autocomplete-suggestion'
@@ -245,19 +248,21 @@
 
         fixPosition: function () {
             var that = this,
-                offset,
+                inputOffset,
+                container,
                 styles;
 
             // Don't adjsut position if custom container has been specified:
-            if (that.options.appendTo !== 'body') {
+            if (!that.options.autoPosition) {
                 return;
             }
-
-            offset = that.el.offset();
-
+            
+            inputOffset = that.el.offset();
+            container = $( that.options.appendTo ).offset();
+            
             styles = {
-                top: (offset.top + that.el.outerHeight()) + 'px',
-                left: offset.left + 'px'
+                top: (inputOffset.top + that.el.outerHeight() - container.top) + 'px',
+                left: (inputOffset.left - container.left) + 'px'
             };
 
             if (that.options.width === 'auto') {


### PR DESCRIPTION
I think this is pretty useful and the implementation isn't too complex. It would address #144, which I know has been closed, but certainly would have been useful to me. I hope you might find it similarly valuable.

By default, this maintains the current behavior, where auto-positioning of the suggestions is only done if the suggestions are appended to the document body. However, if you pass `autoPosition: true` in the options, this will auto-position the suggestions no matter where they are in the DOM.
