### PR TITLE
New option to prevent input text to be changed when user selects a suggestion

### DIFF
--- a/spec/autocompleteBehavior.js
+++ b/spec/autocompleteBehavior.js
@@ -543,6 +543,27 @@ describe('Autocomplete', function () {
         expect(suggestionData).toBeNull();
     });
 
+    it('Should NOT hide suggestions when options.hideOnSelectDisabled is true and item is selected', function() {
+        $('.autocomplete-suggestions').remove();
+
+        var input = $('<input />'),
+            instance,
+            suggestionData = null;
+
+        input.autocomplete({
+            lookup: [{ value: 'Jamaica', data: 'J' }],
+            hideOnSelectDisabled: true
+        });
+
+        input.val('J');
+        instance = input.autocomplete();
+
+        instance.onValueChange();
+        instance.select(0);
+
+        expect($('.autocomplete-suggestions').is(':visible')).toBeTruthy();
+    });
+
     describe('options.changeInputDisabled is true', function() {
        var input = $('<input />'),
            instance,

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -78,6 +78,7 @@
                 triggerSelectOnValidInput: true,
                 preventBadQueries: true,
                 changeInputDisabled: false,
+                hideOnSelectDisabled: false,
                 lookupFilter: function (suggestion, originalQuery, queryLowerCase) {
                     return suggestion.value.toLowerCase().indexOf(queryLowerCase) !== -1;
                 },
@@ -697,7 +698,7 @@
 
         select: function (i) {
             var that = this;
-            that.hide();
+            if (!that.options.hideOnSelectDisabled) { that.hide(); }
             that.onSelect(i);
         },
 


### PR DESCRIPTION
Added changeImputDisabled option to not change the input value when select, move up or down a suggest.

Its good to have an option to behave like imdb.com for example. The actual behavior is similar to youtube and hulu.
