### PR TITLE
Turned cache on for JSONP calls.

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -504,7 +504,9 @@
                     url: serviceUrl,
                     data: params,
                     type: options.type,
-                    dataType: options.dataType
+                    dataType: options.dataType,
+                    jsonpCallback : 'autocompleteCallback',
+                    cache: true
                 }).done(function (data) {
                     var result;
                     that.currentRequest = null;


### PR DESCRIPTION
Turned on cache for JSONP calls which gets rid of the unique jQuery urls in the callback. For more info, see this link:

http://stackoverflow.com/questions/6826307/jsonp-not-caching/16327155#16327155
