### PR TITLE
Adds optional function "transformQuery" to manipulate the query

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -80,6 +80,9 @@
                 lookupFilter: function (suggestion, originalQuery, queryLowerCase) {
                     return suggestion.value.toLowerCase().indexOf(queryLowerCase) !== -1;
                 },
+                transformQuery: function(query) {
+                    return query;
+                },
                 paramName: 'query',
                 transformResult: function (response) {
                     return typeof response === 'string' ? $.parseJSON(response) : response;
@@ -439,12 +442,13 @@
 
         getQuery: function (value) {
             var delimiter = this.options.delimiter,
+                tvalue = this.options.transformQuery(value),
                 parts;
 
             if (!delimiter) {
-                return value;
+                return tvalue;
             }
-            parts = value.split(delimiter);
+            parts = tvalue.split(delimiter);
             return $.trim(parts[parts.length - 1]);
         },
 

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -1,5 +1,5 @@
 /**
-*  Ajax Autocomplete for jQuery, version 1.2.9
+*  Ajax Autocomplete for jQuery, version 1.2.10
 *  (c) 2013 Tomas Kirda
 *
 *  Ajax Autocomplete for jQuery is freely distributable under the terms of an MIT-style license.


### PR DESCRIPTION
`transformQuery` is an optional function that is run in `getQuery` and does nothing by default. It's useful for example to "slugify" the query so that accents are removed before the query is analyzed for matches, etc. (See [underscore-string](https://github.com/epeli/underscore.string) for an example of a slugify function).
