### PR TITLE
Fix main file reference in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Tomas Kirda"
   ],
   "description": "Autocomplete provides suggestions while you type into the text field.",
-  "main": "src/jquery.autocomplete.js",
+  "main": "dist/jquery.autocomplete.js",
   "keywords": [
     "ajax",
     "autocomplete"


### PR DESCRIPTION
This one is supposed to be used, not the source one.

Though I'm not sure how these two differ, I know there are some differences. I think the version needs to be bumped and the package updated in the Bower registry.
