### PR TITLE
Return false in click handler to prevent default behaviour.

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -169,6 +169,7 @@
             // Listen for click event on suggestions list:
             container.on('click.autocomplete', suggestionSelector, function () {
                 that.select($(this).data('index'));
+                return false;
             });
 
             that.fixPosition();


### PR DESCRIPTION
Returning false in the click event handler can be useful, when the input field is located inside of a (bootstrap) dropdown, since it prevents the dropdown getting closed when a suggestion is clicked.