### PR TITLE
Vertical orientation of suggestions. fixPosition and noSuggestionNotice developed.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,10 +42,10 @@ The standard jquery.autocomplete.js file is around 2.7KB when minified via Closu
         * `paramName`: Default `query`. The name of the request parameter that contains the query.
         * `transformResult`: `function(response, originalQuery) {}` called after the result of the query is ready. Converts the result into response.suggestions format.
         * `autoSelectFirst`: if set to `true`, first item will be selected when showing suggestions. Default value `false`.
-        * `appendTo`: container where suggestions will be appended. Default value `body`. Can be jQuery object, selector or html element. Make sure to set `position: absolute` or `position: relative` for that element.
+        * `appendTo`: container where suggestions will be appended. Default value `document.body`. Can be jQuery object, selector or html element. Make sure to set `position: absolute` or `position: relative` for that element.
         * `dataType`: type of data returned from server. Either 'text' (default) or 'jsonp', which will cause the autocomplete to use jsonp. You may return a json object in your callback when using jsonp.
         * `showNoSuggestionNotice`: Default `false`. When no matching results, display a notification label.
-        * `noSuggestionNotice`: Default `No results`. Text for no matching results label.
+        * `noSuggestionNotice`: Default `No results`. Text or htmlString or Element or jQuery object for no matching results label.
         * `forceFixPosition`: Default: `false`. Suggestions are automatically positioned when their container is appended to body (look at `appendTo` option), in other cases suggestions are rendered but no positioning is applied.
            Set this option to force auto positioning in other cases.
         * `orientation`: Default `bottom`. Vertical orientation of the displayed suggestions, available values are `auto`, `top`, `bottom`.


### PR DESCRIPTION
I strongly needed some functionalities for my project, so I developed few new funcs, I hope you consider them useful. Here are the changes.

Suggestions can be placed above (orientation `top`) or below (orientation `bottom`) autocompleted input. Orientation can be also automatically adjusted `auto` so that suggestions are placed closer to the middle of the view port, that minimizes chance of overflowing it.  The solution should be pretty reliable as it was inspired by [bootstap-datepicker](https://github.com/eternicode/bootstrap-datepicker/) code. For backward compatibility default value is `bottom`. 

Second thing is that suggestions can be appended to any node and that does not break `fixPosition` functionality. However by default they behave just as did before, when `appendTo` is not set to  `document.body` the `forceFixPosition` parameter must be `true`.

I also developed noSuggestion functionality. Now, as `noSuggestionNotice` can be set to text htmlString, Element or jQuery object. The two last make the difference when you want to have something like "add another item" Ajax button. Now you can pass node with proper event handlers.

And these might solve #161 and already closed #144. As I said - I hope you find the changes useful.  Regards
