### PR TITLE
Adding global parameter for ajax call

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -89,7 +89,7 @@
                 showNoSuggestionNotice: false,
                 noSuggestionNotice: 'No results',
                 orientation: 'bottom',
-                forceFixPosition: false,
+                forceFixPosition: false
             };
 
         // Shared variables:


### PR DESCRIPTION
Adding global parametr to ajax call.
When ajax is called with global FALSE ajaxStart and ajaxStop are prevented. 
Default value for global is TRUE.
