### PR TITLE
Improvement item for work with others plugins

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -771,9 +771,9 @@
                 activeItem,
                 selected = that.classes.selected,
                 container = $(that.suggestionsContainer),
-                children = container.children();
+                children = container.find('.' + that.classes.suggestion);
 
-            container.children('.' + selected).removeClass(selected);
+            container.find('.' + selected).removeClass(selected);
 
             that.selectedIndex = index;
 


### PR DESCRIPTION
Change jquery children function to find, for search correct item when your structure is modified.

Ex.: 
...
beforeRender: function(){
 $('.autocomplete-suggestions').mCustomScrollbar();
}
...
