### PR TITLE
Use height of items to compute heightDelta

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -851,15 +851,16 @@
 
         adjustScroll: function (index) {
             var that = this,
-                activeItem = that.activate(index),
-                offsetTop,
-                upperBound,
-                lowerBound,
-                heightDelta = 25;
+                activeItem = that.activate(index)
 
             if (!activeItem) {
                 return;
             }
+
+            var offsetTop,
+                upperBound,
+                lowerBound,
+                heightDelta = $(activeItem).outerHeight();
 
             offsetTop = activeItem.offsetTop;
             upperBound = $(that.suggestionsContainer).scrollTop();


### PR DESCRIPTION
## Use case

When using a list with a fixed height set to show an exact number of suggestions, it creates a much better effect if the list scrolls by exactly the height of one suggestion when you use the cursor keys to scroll through.
### Examples

**Before: Using fixed value of `heightDelta: 25` last element is cut off**

![demo_2](https://cloud.githubusercontent.com/assets/104138/4400593/c078501a-4482-11e4-8f43-714b37606a20.gif)

**After: Using automatically calculated value of `heightDelta: 43`**

![demo](https://cloud.githubusercontent.com/assets/104138/4400597/c7dcb54e-4482-11e4-8389-f343dbc99016.gif)

Thanks for an awesome plugin by the way! :thumbsup: 
