### PR TITLE
Auto-select first is not selected by data-index

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -685,9 +685,9 @@
 
             // Select first value by default:
             if (options.autoSelectFirst) {
-                var filter = '[data-index="' + that.selectedIndex + '"]';
                 that.selectedIndex = 0;
                 container.scrollTop(0);
+                var filter = '[data-index="' + that.selectedIndex + '"]';
                 container.children().filter(filter).addClass(classSelected);
             }
 

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -685,9 +685,10 @@
 
             // Select first value by default:
             if (options.autoSelectFirst) {
+                var filter = '[data-index="' + that.selectedIndex + '"]';
                 that.selectedIndex = 0;
                 container.scrollTop(0);
-                container.children().first().addClass(classSelected);
+                container.children().filter(filter).addClass(classSelected);
             }
 
             that.visible = true;


### PR DESCRIPTION
In a custom beforeRender function where I inserts additional dom elements into the autocomplete container and it's first element is not always an autocomplete suggestion item.
The function called 'activate' should be also filtered to data-index attribute.
