### PR TITLE
Fixing custom lookup data in docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,11 +123,13 @@ $('#autocomplete').autocomplete({
     lookup: function (query, done) {
         // Do ajax call or lookup locally, when done,
         // call the callback and pass your results:
-        var results = [
-            { "value": "United Arab Emirates", "data": "AE" },
-            { "value": "United Kingdom",       "data": "UK" },
-            { "value": "United States",        "data": "US" }
-        ];
+        var results = {
+            "suggestions" : [
+               { "value": "United Arab Emirates", "data": "AE" },
+               { "value": "United Kingdom",       "data": "UK" },
+               { "value": "United States",        "data": "US" }
+            ]
+        };
 
         done(results);
     },


### PR DESCRIPTION
As raised in : https://github.com/devbridge/jQuery-Autocomplete/issues/329

`results` object needs to be in the suggestions format, otherwise it'll error.