### PR TITLE
Fix empty response

### DIFF
--- a/dist/jquery.autocomplete.js
+++ b/dist/jquery.autocomplete.js
@@ -584,6 +584,7 @@
                     var result;
                     that.currentRequest = null;
                     result = options.transformResult(data);
+                    if(result.suggestions.length === 0) return;
                     that.processResponse(result, q, cacheKey);
                     options.onSearchComplete.call(that.element, q, result.suggestions);
                 }).fail(function (jqXHR, textStatus, errorThrown) {

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -584,6 +584,7 @@
                     var result;
                     that.currentRequest = null;
                     result = options.transformResult(data);
+                    if(result.suggestions.length === 0) return;
                     that.processResponse(result, q, cacheKey);
                     options.onSearchComplete.call(that.element, q, result.suggestions);
                 }).fail(function (jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
Ignore empty response suggestions and try to fetch again. The server may return empty responses, because it starts searching only if a string of min-length of 3 chars is given (to avoid huge responses).
