### PR TITLE
ShowNoSuggestionNotice can be a function. Fix of noSuggestionNotice.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ The standard jquery.autocomplete.js file is around 2.7KB when minified via Closu
         * `autoSelectFirst`: if set to `true`, first item will be selected when showing suggestions. Default value `false`.
         * `appendTo`: container where suggestions will be appended. Default value `document.body`. Can be jQuery object, selector or html element. Make sure to set `position: absolute` or `position: relative` for that element.
         * `dataType`: type of data returned from server. Either 'text' (default) or 'jsonp', which will cause the autocomplete to use jsonp. You may return a json object in your callback when using jsonp.
-        * `showNoSuggestionNotice`: Default `false`. When no matching results, display a notification label.
+        * `showNoSuggestionNotice`: Default `false`. Boolean or `function (suggestions) {}`. When set `true` and no matching results, display a notification label. When function given, it is called on every suggestion display and if `true` returned, notification is displayed.
         * `noSuggestionNotice`: Default `No results`. Text or htmlString or Element or jQuery object for no matching results label.
         * `forceFixPosition`: Default: `false`. Suggestions are automatically positioned when their container is appended to body (look at `appendTo` option), in other cases suggestions are rendered but no positioning is applied.
            Set this option to force auto positioning in other cases.

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -147,6 +147,7 @@
                 suggestionSelector = '.' + that.classes.suggestion,
                 selected = that.classes.selected,
                 options = that.options,
+                noSuggestionNotice = this.options.noSuggestionNotice,
                 container;
 
             // Remove autocomplete attribute to prevent native suggestions:
@@ -159,9 +160,12 @@
                 }
             };
 
+            // if notice is not string, it should be deep-copied, so every autocomplete instance has its own copy
+            if(typeof noSuggestionNotice !== 'string')
+                noSuggestionNotice = $(noSuggestionNotice).clone(true);
             // html() deals with many types: htmlString or Element or Array or jQuery
             that.noSuggestionsContainer = $('<div class="autocomplete-no-suggestion"></div>')
-                                          .html(this.options.noSuggestionNotice).get(0);
+                                          .html(noSuggestionNotice).get(0);
 
             that.suggestionsContainer = Autocomplete.utils.createNode(options.containerClass);
 
@@ -208,7 +212,6 @@
 
         onFocus: function () {
             var that = this;
-            that.fixPosition();
             if (that.options.minChars <= that.el.val().length) {
                 that.onValueChange();
             }
@@ -634,11 +637,15 @@
 
         suggest: function () {
             if (this.suggestions.length === 0) {
-                if (this.options.showNoSuggestionNotice) {
+
+                var showNoSuggestionNotice = this.options.showNoSuggestionNotice;
+                if(typeof this.options.showNoSuggestionNotice === 'function')
+                    showNoSuggestionNotice = this.options.showNoSuggestionNotice(this.suggestions);
+
+                if(showNoSuggestionNotice)
                     this.noSuggestions();
-                } else {
+                else
                     this.hide();
-                }
                 return;
             }
 
@@ -686,8 +693,16 @@
 
             this.adjustContainerWidth();
 
+            // Detach noSuggestions not to have it removed when filling container with new suggestions
             noSuggestionsContainer.detach();
             container.html(html);
+
+            // If showNoSuggestionNotice is a function, call it to see
+            // if noSuggestionNotice should be added to theses suggestions
+            if(typeof this.options.showNoSuggestionNotice === 'function'
+                && this.options.showNoSuggestionNotice(that.suggestions)) {
+                container.append(noSuggestionsContainer);
+            }
 
             if ($.isFunction(beforeRender)) {
                 beforeRender.call(that.element, container);


### PR DESCRIPTION
Hey there.
I added option to specify function as showNoSuggestionNotice. It's helpful when there is need to dynamically decide weather to display noSuggestionNotice or not. The function takes suggestions as only argument, thanks to that You can decide to show notice when e.g suggestions are shorter than 3.
