### PR TITLE
remove_highlights_for_arabic_words

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -134,13 +134,15 @@
         
         var pattern = '(' + utils.escapeRegExChars(currentValue) + ')';
 
-        return suggestion.value
-            .replace(new RegExp(pattern, 'gi'), '<strong>$1<\/strong>')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/&lt;(\/?strong)&gt;/g, '<$1>');
+        var arabic_regex = /[\u0600-\u06FF]/; // Arabic characters fall in the Unicode range 0600 - 06FF
+        return (arabic_regex.test(suggestion.value) ? suggestion.value : suggestion.value
+                                                                                    .replace(new RegExp(pattern, 'gi'), '<strong>$1<\/strong>')
+                                                                                    .replace(/&/g, '&amp;')
+                                                                                    .replace(/</g, '&lt;')
+                                                                                    .replace(/>/g, '&gt;')
+                                                                                    .replace(/"/g, '&quot;')
+                                                                                    .replace(/&lt;(\/?strong)&gt;/g, '<$1>')
+                                                                                  );
     };
 
     Autocomplete.prototype = {


### PR DESCRIPTION
hello,
highlighting a letter in arabic while keeping the other non highlighted breaks the word and make it unreadable :sweat_smile: 
### How it is
<img width="420" alt="screen shot 2016-02-10 at 2 11 20 pm" src="https://cloud.githubusercontent.com/assets/9535792/12947609/418471de-d005-11e5-819e-edd7b7f89f79.png">

### How it should be
![screen shot 2016-02-10 at 2 50 12 pm](https://cloud.githubusercontent.com/assets/9535792/12947666/be357d7c-d005-11e5-9b78-afc497649217.png)

this is a well known issue in the world with arabic language :cry: 

| chrome    |  gmail |
| ------------- | ------------- |
| <img width="250" alt="screen shot 2016-02-10 at 2 16 16 pm" src="https://cloud.githubusercontent.com/assets/9535792/12947726/2cfc4416-d006-11e5-8c23-81dff71067ec.png">  | <img width="400" alt="screen shot 2016-02-10 at 2 35 21 pm" src="https://cloud.githubusercontent.com/assets/9535792/12947734/357ce9f6-d006-11e5-9bc3-cf82de5633ee.png"> 

so i propose no highlights if the word is in arabic (until a better solution is found) :smile: 