### PR TITLE
Adding suggestions data variable to beforeRenderer callback.

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -688,7 +688,7 @@
             container.html(html);
 
             if ($.isFunction(beforeRender)) {
-                beforeRender.call(that.element, container);
+                beforeRender.call(that.element, container, that.data);
             }
 
             that.fixPosition();


### PR DESCRIPTION
The reason I implemented that was to be able to build a <img> on each suggestion using data from the suggestions array.

```javascript
           beforeRender: function (container, data) {
                var c = 0;
                $(container).find('div.autocomplete-suggestion').each(function(){
                    $(this).prepend('<img src="' + ENV.apiEndpoint + data[c].data.photo + '">');
                    c++;
                });
            }
```