### PR TITLE
allow formatGroup template

### DIFF
--- a/dist/jquery.autocomplete.js
+++ b/dist/jquery.autocomplete.js
@@ -67,6 +67,7 @@
                 deferRequestBy: 0,
                 params: {},
                 formatResult: Autocomplete.formatResult,
+                formatGroup: Autocomplete.formatGroup,
                 delimiter: null,
                 zIndex: 9999,
                 type: 'GET',
@@ -141,6 +142,11 @@
             .replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;')
             .replace(/&lt;(\/?strong)&gt;/g, '<$1>');
+    };
+
+    Autocomplete.formatGroup = function (suggestion, category) {
+       // Do not replace anything if there current value is empty
+       return '<div class="autocomplete-group"><strong>' + category + '</strong></div>';
     };
 
     Autocomplete.prototype = {
@@ -666,7 +672,7 @@
 
                         category = currentCategory;
 
-                        return '<div class="autocomplete-group"><strong>' + category + '</strong></div>';
+                        return options.formatGroup(suggestion, category);
                     };
 
             if (options.triggerSelectOnValidInput && that.isExactMatch(value)) {


### PR DESCRIPTION
This update allows styling of formatGroup by extending the initialization options and then return partial html.

Example when initializing formatGroup, in this case we are removing the `<strong>` tags.

`
formatGroup : function(suggestion, category) {
     return '<div class="autocomplete-group">' + category + '</div>';
},`
