### PR TITLE
Shorter RegEx in escapeRegExChars

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -29,7 +29,7 @@
         utils = (function () {
             return {
                 escapeRegExChars: function (value) {
-                    return value.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+                    return value.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
                 },
                 createNode: function (containerClass) {
                     var div = document.createElement('div');


### PR DESCRIPTION
* Removed unnecessary backslash characters.
* Slash character is not a regex special character and does not need to be escaped.


Reference: https://github.com/sindresorhus/escape-string-regexp/blob/master/index.js