### PR TITLE
add onChange callback function to fix onSelect and onChange conflicting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ The standard jquery.autocomplete.js file is around 13KB when minified.
 * `transformResult`: `function(response, originalQuery) {}` called after the result of the query is ready. Converts the result into response.suggestions format.
 * `onSelect`: `function (suggestion) {}` Callback function invoked when user selects suggestion
   from the list. `this` inside callback refers to input HtmlElement.
+* `onChange`: `function (value) {}` Callback function invoked when on change event.
 * `minChars`: Minimum number of characters required to trigger autosuggest. Default: `1`.
 * `lookupLimit`: Number of maximum results to display for local lookup. Default: no limit.
 * `lookup`: Callback function or lookup array for the suggestions. It may be array of strings or `suggestion` object literals.
@@ -149,6 +150,21 @@ $('#autocomplete').autocomplete({
         alert('You selected: ' + suggestion.value + ', ' + suggestion.data);
     }
 });
+```
+
+Use onChange:
+
+```javascript
+$('#autocomplete').autocomplete({
+    serviceUrl: '/autocomplete/countries',
+    onSelect: function (suggestion) {
+        alert('You selected: ' + suggestion.value + ', ' + suggestion.data);
+    },
+    onChange: function (value) {
+        console.log(value);
+    }
+});
+
 ```
 
 ##Styling

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -208,7 +208,7 @@
             that.el.on('keyup.autocomplete', function (e) { that.onKeyUp(e); });
             that.el.on('blur.autocomplete', function () { that.onBlur(); });
             that.el.on('focus.autocomplete', function () { that.onFocus(); });
-            that.el.on('change.autocomplete', function (e) { that.onKeyUp(e); });
+            that.el.on('change.autocomplete', function (e) { $(that).data("_change.autocomplete", setTimeout(function () { if ($.isFunction(that.options.onChange)) { that.options.onChange(that.el.val()); } }, 500)) });
             that.el.on('input.autocomplete', function (e) { that.onKeyUp(e); });
         },
 
@@ -913,6 +913,7 @@
         },
 
         onSelect: function (index) {
+            clearTimeout($(this).data("_change.autocomplete"));
             var that = this,
                 onSelectCallback = that.options.onSelect,
                 suggestion = that.suggestions[index];


### PR DESCRIPTION
Use onChange:

``` javascript
$('#autocomplete').autocomplete({
    serviceUrl: '/autocomplete/countries',
    onSelect: function (suggestion) {
        alert('You selected: ' + suggestion.value + ', ' + suggestion.data);
    },
    onChange: function (value) {
        console.log(value);
    }
});

```
