### PR TITLE
- Replaced $.parseJSON with JSON.parse(), following jQuery 3.0 upgrad…

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -86,7 +86,7 @@
                 },
                 paramName: 'query',
                 transformResult: function (response) {
-                    return typeof response === 'string' ? $.parseJSON(response) : response;
+                    return typeof response === 'string' ? JSON.parse(response) : response;
                 },
                 showNoSuggestionNotice: false,
                 noSuggestionNotice: 'No results',


### PR DESCRIPTION
I have replaced $.parseJSON with JSON.parse(), following jQuery 3.0 upgrade guide (https://jquery.com/upgrade-guide/3.0/#deprecated-jquery-parsejson)