### PR TITLE
New feature for options.params

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -553,7 +553,7 @@
                 ajaxSettings;
 
             options.params[options.paramName] = q;
-            params = options.ignoreParams ? null : options.params;
+            params = options.ignoreParams ? null : (typeof(options.params) == 'function' ? options.params.call(that.element) : options.params);
 
             if (options.onSearchStart.call(that.element, options.params) === false) {
                 return;


### PR DESCRIPTION
Added support for use callback function instead of dictionary in
options.params. This need for dynamically set custom Ajax parameters.

Example:

```
$(el).autocomplete({
	params : function() {
		return {
			foo : this.dataset.foo,
			bar : this.dataset.bar,
			baz : this.id,
			val : this.value
			... etc. as you wish ...
		};
	}
})
```