### PR TITLE
add the ajaxSetter option

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -56,6 +56,7 @@
             that = this,
             defaults = {
                 ajaxSettings: {},
+                ajaxSetter: null,
                 autoSelectFirst: false,
                 appendTo: document.body,
                 serviceUrl: null,
@@ -593,6 +594,9 @@
                 };
 
                 $.extend(ajaxSettings, options.ajaxSettings);
+
+                $.isFunction(options.ajaxSetter) &&
+                    options.ajaxSetter(q, ajaxSettings)
 
                 that.currentRequest = $.ajax(ajaxSettings).done(function (data) {
                     var result;


### PR DESCRIPTION
provide a way to rearange the settings of the ajax request just before
sending the request.

there is no doc, no test and and it introduce at least one bug we need to talk about. (https://github.com/eiro/eiro.github.com/blob/master/notes/jquery-autocomplete.md) i i saw now developper mailing list. if you're interested, i'm eiro on freenode too.

regards
