### PR TITLE
Fixed a bug where the suggestion list briefly flashes when the select…

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -853,6 +853,7 @@
             var that = this;
             that.hide();
             that.onSelect(i);
+            that.disableKillerFn();
         },
 
         moveUp: function () {


### PR DESCRIPTION
…ed suggestion is a prefix of another suggestion.  Prior to this fix, the problem can be reproduced as follows:

1. Open the index.html demo (this url is convenient: https://rawgit.com/devbridge/jQuery-Autocomplete/master/index.htm)
2. In the country name field type "N" then select "Niger" from the list (this country is a prefix for "Nigeria").
3. Click the country name field again.  The suggestion list will flash briefly then dissappear.  The user must then click off of the field and back onto it to actually see the suggestion list.