### PR TITLE
fix  getQuery  return empty string:

### DIFF
--- a/dist/jquery.autocomplete.js
+++ b/dist/jquery.autocomplete.js
@@ -508,6 +508,11 @@
             if (!delimiter) {
                 return value;
             }
+
+            if( delimiter == value ){
+                return $.trim(value)
+            }
+
             parts = value.split(delimiter);
             return $.trim(parts[parts.length - 1]);
         },


### PR DESCRIPTION
when I input Chinese，the delimiter will equal value, and function getQuery  return an empty string;