### PR TITLE
Fix typo in src/jquery.autocomplete.js

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -134,7 +134,7 @@
     };
 
     function _formatResult(suggestion, currentValue) {
-        // Do not replace anything if there current value is empty
+        // Do not replace anything if the current value is empty
         if (!currentValue) {
             return suggestion.value;
         }


### PR DESCRIPTION
There was a small typo in `src/jquery.autocomplete.js`: "there" should be "the". This PR fixes that.