### PR TITLE
fix blurring of menu

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -198,8 +198,8 @@
                 that.select($(this).data('index'));
             });
 
-            container.on('mousedown.autocomplete', function () {
-                clearTimeout(that.blurTimeoutId);
+            container.on('mousedown.autocomplete', function (e) {
+                e.preventDefault();
             })
 
             that.fixPositionCapture = function () {
@@ -229,13 +229,7 @@
         },
 
         onBlur: function () {
-            var that = this;
-
-            // If user clicked on a suggestion, hide() will
-            // be canceled, otherwise close suggestions
-            that.blurTimeoutId = setTimeout(function () {
-                that.hide();
-            }, 200);
+            this.hide();
         },
         
         abortAjax: function () {

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -198,7 +198,7 @@
                 that.select($(this).data('index'));
             });
 
-            container.on('click.autocomplete', function () {
+            container.on('mousedown.autocomplete', function () {
                 clearTimeout(that.blurTimeoutId);
             })
 


### PR DESCRIPTION
if you click and hold (without releasing mouse), the dropdown will still blur/hide. This is because the order of events goes

mousedown -> blur -> mouseup -> click

So basically you must click "quickly" or lose the menu