### PR TITLE
Introduce callbacks to hide and show container.

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -122,7 +122,9 @@
             showNoSuggestionNotice: false,
             noSuggestionNotice: 'No results',
             orientation: 'bottom',
-            forceFixPosition: false
+            forceFixPosition: false,
+            showCallback: false,
+            hideCallback: false
     };
 
     function _lookupFilter(suggestion, originalQuery, queryLowerCase) {
@@ -138,7 +140,7 @@
         if (!currentValue) {
             return suggestion.value;
         }
-        
+
         var pattern = '(' + utils.escapeRegExChars(currentValue) + ')';
 
         return suggestion.value
@@ -237,7 +239,7 @@
                 that.hide();
             }, 200);
         },
-        
+
         abortAjax: function () {
             var that = this;
             if (that.currentRequest) {
@@ -616,7 +618,13 @@
             that.visible = false;
             that.selectedIndex = -1;
             clearTimeout(that.onChangeTimeout);
-            $(that.suggestionsContainer).hide();
+
+            if ($.isFunction(that.options.hideCallback)) {
+                that.options.hideCallback.call(container);
+            } else {
+                container.hide();
+            }
+
             that.signalHint(null);
         },
 
@@ -678,7 +686,12 @@
             }
 
             that.fixPosition();
-            container.show();
+
+            if ($.isFunction(that.options.showCallback)) {
+                that.options.showCallback.call(container);
+            } else {
+                container.show();
+            }
 
             // Select first value by default:
             if (options.autoSelectFirst) {
@@ -704,7 +717,7 @@
             noSuggestionsContainer.detach();
 
             // clean suggestions if any
-            container.empty(); 
+            container.empty();
             container.append(noSuggestionsContainer);
 
             if ($.isFunction(beforeRender)) {


### PR DESCRIPTION
Instead of using the "on" callbacks that for hide and show behavior,
allowing a callback will prevent the original functions to be called.

So for example, if I want to use slideUp/slideDown the animate effect will not be
performed because the show/hide will be performed before the animated functions.