### PR TITLE
Use global jquery reference

### DIFF
--- a/typings/jquery-autocomplete/jquery.autocomplete.d.ts
+++ b/typings/jquery-autocomplete/jquery.autocomplete.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: John Gouigouix <https://github.com/orchestra-ts/DefinitelyTyped/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../jquery/jquery.d.ts"/>
+/// <reference types="jquery"/>
 
 interface AutocompleteSuggestion {
 


### PR DESCRIPTION
This creates a conflict if the app implementing already has a version of jquery. This should be pulled from the global definition of jquery.