### PR TITLE
fixes TAB and RETURN keys behaviour

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -62,6 +62,7 @@
         that.suggestions = [];
         that.badQueries = [];
         that.selectedIndex = -1;
+        that.selectedBy = 'other'; // what changed selectedIndex ? possible values: 'keyboard','mouse' or 'other'
         that.currentValue = that.element.value;
         that.timeoutId = null;
         that.cachedResponse = {};
@@ -183,6 +184,7 @@
 
             // Listen for mouse over event on suggestions list:
             container.on('mouseover.autocomplete', suggestionSelector, function () {
+				that.selectedBy = 'mouse';
                 that.activate($(this).data('index'));
             });
 
@@ -392,11 +394,13 @@
                     }
                     return;
                 case keys.TAB:
+					// select suggestion only if it was selected by keyboard, not by mouse.
+					// Hint is an exception from this rule:
                     if (that.hint && that.options.onHint) {
                         that.selectHint();
                         return;
                     }
-                    if (that.selectedIndex === -1) {
+                    if (that.selectedIndex === -1 || that.selectedBy !== 'keyboard') {
                         that.hide();
                         return;
                     }
@@ -406,7 +410,8 @@
                     }
                     break;
                 case keys.RETURN:
-                    if (that.selectedIndex === -1) {
+					// select suggestion only if it was selected by keyboard, not by mouse.
+                    if (that.selectedIndex === -1 || that.selectedBy !== 'keyboard') {
                         that.hide();
                         return;
                     }
@@ -857,6 +862,8 @@
                 return;
             }
 
+			that.selectedBy = 'keyboard';
+
             if (that.selectedIndex === 0) {
                 $(that.suggestionsContainer).children().first().removeClass(that.classes.selected);
                 that.selectedIndex = -1;
@@ -871,6 +878,8 @@
 
         moveDown: function () {
             var that = this;
+
+			that.selectedBy = 'keyboard';
 
             if (that.selectedIndex === (that.suggestions.length - 1)) {
                 return;


### PR DESCRIPTION
Hi!
This patch chages bahaviour when using Tab and Enter to be more consistent with plugin role.

**Why:**
Warning: it is not easy to understand what is wrong, so be ready for some brain work :)

After using this plugin for some time on production website I realised that there is something wrong with it. Fixing it without changing source code went impossible.

Whats wrong:

- It is impossible to enter short values to the input field USING Tab and Enter keys IF there are longer results in suggestions area AND if mouse pointer is over those results (accidentely it is always there).

This is because active suggestion is changed by mouseover event.

**How it should work:**

It should be possible to enter any value and finish entering it with Tab or Enter without modification and without generating select action on plugin, wherever mouse pointer is. More strictly - suggestion selection using Tab and Enter should fire only when suggestion was chosen by UP and Down keys, not by mouse.

**How to reproduce:**

- Open demo jQuery-Autocomplete/index.htm from the source (can't find it online)
- Click to the second example (first uses Hint and should work as it is) under "Type NHL or NBA team name:" input field
- move mouse pointer down a bit, to the "Container" word
- Try to enter letter "a" and push Tab, this will result to 'Atlanta Thrashers'' selection.
- As you can see, without moving mouse pointer outside of suggestion area it is impossible to enter "a" symbol to this field
- Go to google.com and try the same with their suggestion field - google behaves corectly

**Patch**

Patch provided.
