### PR TITLE
Fix keyboard navigation of the grouped list

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -859,7 +859,7 @@
             }
 
             if (that.selectedIndex === 0) {
-                $(that.suggestionsContainer).children().first().removeClass(that.classes.selected);
+                $(that.suggestionsContainer).children('.' + that.classes.suggestion).first().removeClass(that.classes.selected);
                 that.selectedIndex = -1;
                 that.ignoreValueChange = false;
                 that.el.val(that.currentValue);


### PR DESCRIPTION
We have to remove class from first suggestion element, not from every first children. Otherwise, in case of a grouped list, first item never lose selected state.