### PR TITLE
Fix disabling autofill in last versions of Chrome

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -164,7 +164,7 @@
                 container;
 
             // Remove autocomplete attribute to prevent native suggestions:
-            that.element.setAttribute('autocomplete', 'off');
+            that.element.setAttribute('autocomplete', 'new-password');
 
             // html() deals with many types: htmlString or Element or Array or jQuery
             that.noSuggestionsContainer = $('<div class="autocomplete-no-suggestion"></div>')


### PR DESCRIPTION
Last versions of Google Chrome ignore property 'autocomplete="off"'. We need change it to 'autocomplete="new-password"' for disabling internal Chrome autofill feature when plugin initialized. It works for any text fields, not only for password text fields.

Change
            // Remove autocomplete attribute to prevent native suggestions:
            that.element.setAttribute('autocomplete', 'off');
to:
            // Remove autocomplete attribute to prevent native suggestions:
            that.element.setAttribute('autocomplete', 'new-password');

Proof: https://stackoverflow.com/questions/15738259/disabling-chrome-autofill