### PR TITLE
Added option to show dropdown when clicking on the input

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -122,7 +122,8 @@
             showNoSuggestionNotice: false,
             noSuggestionNotice: 'No results',
             orientation: 'bottom',
-            forceFixPosition: false
+            forceFixPosition: false,
+            showOnFocus: false
     };
 
     function _lookupFilter(suggestion, originalQuery, queryLowerCase) {
@@ -224,6 +225,9 @@
 
             if (that.el.val().length >= that.options.minChars) {
                 that.onValueChange();
+                if (that.options.showOnFocus) {
+                    that.getSuggestions('');
+                }
             }
         },
 


### PR DESCRIPTION
This adds the convenience of being able to see dropdown options without having to type first as long as the input meets the minChars requirement.

It allows it perform a little more like a traditional dropdown while providing all the functionality of this autocomplete extension.