### PR TITLE
Fix chrome autocomplete issue

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -164,7 +164,11 @@
                 container;
 
             // Remove autocomplete attribute to prevent native suggestions:
-            that.element.setAttribute('autocomplete', 'off');
+            // as per
+            // https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
+            // some browsers e.g. Google Chrome ignore autocomplete=off but autocomplete=nope
+            // will provide the correct behaviour
+            that.element.setAttribute('autocomplete', 'nope');
 
             // html() deals with many types: htmlString or Element or Array or jQuery
             that.noSuggestionsContainer = $('<div class="autocomplete-no-suggestion"></div>')


### PR DESCRIPTION
As per
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

Some browsers e.g. Google Chrome ignore autocomplete=off but autocomplete=nope will provide the correct behaviour.