### PR TITLE
forceFixPosition should set position: fixed in suggestion container

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -319,6 +319,10 @@
                 offset = that.el.offset(),
                 styles = { 'top': offset.top, 'left': offset.left };
 
+            if (that.options.forceFixPosition) {
+                styles.position = 'fixed';
+            }
+
             if (orientation === 'auto') {
                 var viewPortHeight = $(window).height(),
                     scrollTop = $(window).scrollTop(),

--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -219,6 +219,10 @@
         onFocus: function () {
             var that = this;
 
+            if (that.disabled) {
+                return;
+            }
+
             that.fixPosition();
 
             if (that.el.val().length >= that.options.minChars) {
@@ -270,7 +274,7 @@
                 'z-index': options.zIndex
             });
 
-            this.options = options;            
+            this.options = options;
         },
 
 


### PR DESCRIPTION
Using Zurb Foundation 6.5.3, and found that Autocomplete does not show the suggestions box correctly in Reveal modals.  I believe Reveal modals are fixed position, so the suggestions box needs the same position setting.

Also noticed that forceFixPosition is only used in one other location, and I did not have an example of how that would work.  I am not an expert in the code, but I found this simple fix solved my problem. Not sure of other impacts for people using forceFixPosition, so that needs to be checked.