### PR TITLE
Increase timeout for blurTimeout

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -244,7 +244,7 @@
                 if (that.selection && that.currentValue !== query) {
                     (options.onInvalidateSelection || $.noop).call(that.element);
                 }
-            }, 200);
+            }, 350);
         },
 
         abortAjax: function () {


### PR DESCRIPTION
Fixes #809. If someone is a "slow clicker" it can happen that the autocomplete selection is closed instead of triggering the click event. You can try this when holding the left mouse button for a short time, this increases the timeout a bit to make it more likely that the click event is triggered.