### PR TITLE
Fixed when empty query added as bad query in case of no results

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -819,7 +819,7 @@
             // Cache results if cache is not disabled:
             if (!options.noCache) {
                 that.cachedResponse[cacheKey] = result;
-                if (options.preventBadQueries && !result.suggestions.length) {
+                if (options.preventBadQueries && !result.suggestions.length && originalQuery) {
                     that.badQueries.push(originalQuery);
                 }
             }


### PR DESCRIPTION
There was an issue when empty query was ran but no result given, the code did not even try to query result when empty search did not give results.