### PR TITLE
fix: missing typings in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "files": [
     "dist/",
-    "typings/jquery-autocomplete/*.d.ts",
+    "typings/*.d.ts",
     "readme.md"
   ]
 }


### PR DESCRIPTION
I noticed the typings were missing in the NPM package, due to an outdated path.